### PR TITLE
tent_end_to_end_dcp.py: retrieve results bundle manifest and check it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 
 test:
-	python -m unittest discover
+	PYTHONWARNINGS=ignore:ResourceWarning python -m unittest discover

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import sys
 
+
 def progress(message):
     sys.stdout.write(message)
     sys.stdout.flush()


### PR DESCRIPTION
Also added DataStoreAgent download_bundle() and download_file() for future use.