### PR TITLE
Add 10x pipeline to DCP-wide integration test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -27,6 +27,7 @@ dcp_wide_test_SS2:
   stage: dcp_wide_test
   only:
     - integration
+    - se-add-10x-run
   script:
     - CI_COMMIT_REF_NAME=integration python -m unittest tests.integration.test_end_to_end_dcp.TestSmartSeq2Run.test_smartseq2_run
 
@@ -34,6 +35,7 @@ dcp_wide_test_10x:
   stage: dcp_wide_test
   only:
     - integration
+    - se-add-10x-run
   script:
     - CI_COMMIT_REF_NAME=integration python -m unittest tests.integration.test_end_to_end_dcp.Test10xRun.test_10x_run
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,10 +19,23 @@ before_script:
 dcp_wide_test:
   stage: dcp_wide_test
   only:
-    - integration
     - staging
   script:
     - make test
+
+dcp_wide_test_SS2:
+  stage: dcp_wide_test
+  only:
+    - integration
+  script:
+    - CI_COMMIT_REF_NAME=integration python -m unittest tests.integration.test_end_to_end_dcp.TestSmartSeq2Run.test_smartseq2_run
+
+dcp_wide_test_10x:
+  stage: dcp_wide_test
+  only:
+    - integration
+  script:
+    - CI_COMMIT_REF_NAME=integration python -m unittest tests.integration.test_end_to_end_dcp.Test10xRun.test_10x_run
 
 100_cell_test:
   stage: 100_cell_test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,18 +16,11 @@ before_script:
   - aws configure set default.s3.multipart_threshold 64MB
   - aws configure set default.s3.multipart_chunksize 64MB
 
-dcp_wide_test:
-  stage: dcp_wide_test
-  only:
-    - staging
-  script:
-    - make test
-
 dcp_wide_test_SS2:
   stage: dcp_wide_test
   only:
     - integration
-    - se-add-10x-run
+    - staging
   script:
     - CI_COMMIT_REF_NAME=integration python -m unittest tests.integration.test_end_to_end_dcp.TestSmartSeq2Run.test_smartseq2_run
 
@@ -35,7 +28,6 @@ dcp_wide_test_10x:
   stage: dcp_wide_test
   only:
     - integration
-    - se-add-10x-run
   script:
     - CI_COMMIT_REF_NAME=integration python -m unittest tests.integration.test_end_to_end_dcp.Test10xRun.test_10x_run
 

--- a/tests/dataset_fixture.py
+++ b/tests/dataset_fixture.py
@@ -39,7 +39,7 @@ class DatasetFixture:
 
     def update_spreadsheet_project_shortname(self, new_shortname):
         project_tab = self.spreadsheet['Project']
-        if project_tab['A2'].value != "Project shortname":
+        if project_tab['A4'].value != "project.project_core.project_short_name":
             raise RuntimeError("Project shortname is no longer in cell project!A2")
         project_tab['A6'] = new_shortname
         self.spreadsheet.save(filename=self.metadata_spreadsheet_path)

--- a/tests/fixtures/datasets/10x/README.json
+++ b/tests/fixtures/datasets/10x/README.json
@@ -1,0 +1,5 @@
+{
+  "data_files_location": "s3://org-humancellatlas-dcp-test-data/10x/",
+  "spreadsheet_location": "https://raw.github.com/HumanCellAtlas/metadata-schema/DEPLOYMENT/infrastructure_testing_files/current/dcp_integration_test_metadata_1_10X_bundle.xlsx",
+  "expected_bundle_count": 1
+}

--- a/tests/integration/test_end_to_end_dcp.py
+++ b/tests/integration/test_end_to_end_dcp.py
@@ -107,5 +107,34 @@ class TestSmartSeq2Run(TestEndToEndDCP):
         self.check_manifest_contains_exactly_these_files(results_bundle_manifest, expected_files)
 
 
+class Test10xRun(TestEndToEndDCP):
+
+    CELLRANGER_10X_ANALYSIS_OUTPUT_FILES_REGEXES = [
+        re.compile('metrics\_summary\.csv$'),
+        re.compile('possorted\_genome\_bam\.bam$'),
+        re.compile('possorted\_genome\_bam\.bam\.bai$'),
+        re.compile('barcodes\.tsv$'),
+        re.compile('genes\.tsv$'),
+        re.compile('matrix\.mtx$'),
+        re.compile('filtered\_gene\_bc\_matrices\_h5.h5$'),
+        re.compile('raw\_gene\_bc\_matrices\_h5.h5$'),
+        re.compile('raw\_barcodes\.tsv$'),
+        re.compile('raw\_genes\.tsv$'),
+        re.compile('raw\_matrix\.mtx$'),
+        re.compile('molecule\_info\.h5$'),
+        re.compile('web\_summary\.html$')
+    ]
+
+    def test_10x_run(self):
+        runner = self.ingest_store_and_analyze_dataset(dataset_fixture='10x')
+        self.assertEqual(1, len(runner.primary_bundle_uuids))
+        self.assertEqual(1, len(runner.secondary_bundle_uuids))
+        expected_files = self.expected_results_bundle_files(runner.primary_bundle_uuids[0],
+                                                            self.CELLRANGER_10X_ANALYSIS_OUTPUT_FILES_REGEXES)
+        results_bundle_manifest = self.data_store.bundle_manifest(runner.secondary_bundle_uuids[0])
+
+        self.check_manifest_contains_exactly_these_files(results_bundle_manifest, expected_files)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Add a test for the 10x cellranger pipeline 
- Separate the gitlab job for `dcp_wide_test` into a separate job for each pipeline. Since the stage is the same for both jobs, the dcp_wide_test pipeline will run both of them in parallel:  

![screen shot 2018-10-16 at 3 01 02 pm](https://user-images.githubusercontent.com/6414394/47040569-82fee100-d154-11e8-87e7-ea5356631315.png)



Fixes: https://github.com/HumanCellAtlas/secondary-analysis/issues/248

Note: The 10x test will only pass in the `integration` environment, until [this fix](https://github.com/HumanCellAtlas/pipeline-tools/pull/90) to the pipeline outputs is promoted to the `staging`environment for secondary analysis.