### PR TITLE
Ingest headers must always get the cached and refreshed token

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,6 @@ dcp_wide_test_SS2:
     - integration
     - staging
     - prod
-    - aa-token-refresh
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.TestSmartSeq2Run.test_smartseq2_run
 
@@ -35,7 +34,6 @@ dcp_wide_test_10x:
     - integration
     - staging
     - prod
-    - aa-token-refresh
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.Test10xRun.test_10x_run
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,7 @@ dcp_wide_test_SS2:
     - integration
     - staging
     - prod
+    - aa-token-refresh
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.TestSmartSeq2Run.test_smartseq2_run
 
@@ -34,6 +35,7 @@ dcp_wide_test_10x:
     - integration
     - staging
     - prod
+    - aa-token-refresh
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.Test10xRun.test_10x_run
 

--- a/tests/dataset_runner.py
+++ b/tests/dataset_runner.py
@@ -144,7 +144,8 @@ class DatasetRunner:
     def complete_submission(self):
         Progress.report("COMPLETING SUBMISSION...")
         submit_url = self.submission_envelope.data['_links']['submit']['href']
-        response = requests.put(submit_url, headers=self.ingest_api.auth_headers)
+        headers = self.ingest_api.ingest_auth_agent.make_auth_header()
+        response = requests.put(submit_url, headers=headers)
         if response.status_code != requests.codes.accepted:
             raise RuntimeError(f"PUT {submit_url} returned {response.status_code}: {response.content}")
         Progress.report("  done.\n")

--- a/tests/ingest_agents.py
+++ b/tests/ingest_agents.py
@@ -18,12 +18,12 @@ class IngestUIAgent:
         else:
             self.ingest_broker_url = self.INGEST_UI_URL_TEMPLATE.format(self.deployment)
         self.ingest_auth_agent = IngestAuthAgent()
-        self.auth_headers = self.ingest_auth_agent.make_auth_header()
 
     def upload(self, metadata_spreadsheet_path):
         url = self.ingest_broker_url + '/api_upload'
         files = {'file': open(metadata_spreadsheet_path, 'rb')}
-        response = requests.post(url, files=files, allow_redirects=False, headers=self.auth_headers)
+        headers = self.ingest_auth_agent.make_auth_header()
+        response = requests.post(url, files=files, allow_redirects=False, headers=headers)
         if response.status_code != requests.codes.found and response.status_code != requests.codes.created:
             raise RuntimeError(f"POST {url} response was {response.status_code}: {response.content}")
         return json.loads(response.content)['details']['submission_id']
@@ -34,7 +34,7 @@ class IngestApiAgent:
     def __init__(self, deployment):
         self.deployment = deployment
         self.ingest_api_url = self._ingest_api_url()
-        self.auth_headers = IngestAuthAgent().make_auth_header()
+        self.ingest_auth_agent = IngestAuthAgent()
 
     def project(self, project_id):
         return IngestApiAgent.Project(project_id=project_id, ingest_api_agent=self)
@@ -84,7 +84,7 @@ class IngestApiAgent:
         else:
             url = f"{self.ingest_api_url}{path_or_url}"
 
-        response = requests.get(url, headers=self.auth_headers)
+        response = requests.get(url, headers=self.ingest_auth_agent.make_auth_header())
 
         if response.ok:
             return response.json()


### PR DESCRIPTION
Retrieving the headers every request should be fine since token manager inside hca-ingest is handling the caching and refreshing the token (every ~1hr)

https://allspark.dev.data.humancellatlas.org/HumanCellAtlas/dcp/-/jobs/19037