### PR TITLE
Timeout should actually wrap test logic

### DIFF
--- a/tests/integration/test_end_to_end_dcp.py
+++ b/tests/integration/test_end_to_end_dcp.py
@@ -104,7 +104,7 @@ class TestSmartSeq2Run(TestEndToEndDCP):
     ]
 
     def test_smartseq2_run(self):
-        with Timeout(6) as to:  # timeout after 1 hour and 50 minutes
+        with Timeout(110 * 60) as to:  # timeout after 1 hour and 50 minutes
             runner = self.ingest_store_and_analyze_dataset(dataset_fixture='Smart-seq2')
             try:
                 self.assertEqual(1, len(runner.primary_bundle_uuids))
@@ -142,7 +142,7 @@ class Test10xRun(TestEndToEndDCP):
     ]
 
     def test_10x_run(self):
-        with Timeout(6) as to:  # timeout after 1 hour and 50 minutes
+        with Timeout(110 * 60) as to:  # timeout after 1 hour and 50 minutes
             runner = self.ingest_store_and_analyze_dataset(dataset_fixture='10x')
             try:
                 self.assertEqual(1, len(runner.primary_bundle_uuids))

--- a/tests/integration/test_end_to_end_dcp.py
+++ b/tests/integration/test_end_to_end_dcp.py
@@ -104,9 +104,8 @@ class TestSmartSeq2Run(TestEndToEndDCP):
     ]
 
     def test_smartseq2_run(self):
-        runner = self.ingest_store_and_analyze_dataset(dataset_fixture='Smart-seq2')
-
-        with Timeout(110 * 60) as to:  # timeout after 1 hour and 50 minutes
+        with Timeout(6) as to:  # timeout after 1 hour and 50 minutes
+            runner = self.ingest_store_and_analyze_dataset(dataset_fixture='Smart-seq2')
             try:
                 self.assertEqual(1, len(runner.primary_bundle_uuids))
                 self.assertEqual(1, len(runner.secondary_bundle_uuids))
@@ -117,6 +116,9 @@ class TestSmartSeq2Run(TestEndToEndDCP):
                 self.check_manifest_contains_exactly_these_files(results_bundle_manifest, expected_files)
             except:
                 pass
+
+        print()
+        print("test timed out:", to.did_timeout)
 
         runner.cleanup_primary_and_result_bundles()
 
@@ -140,9 +142,8 @@ class Test10xRun(TestEndToEndDCP):
     ]
 
     def test_10x_run(self):
-        runner = self.ingest_store_and_analyze_dataset(dataset_fixture='10x')
-
-        with Timeout(110 * 60) as to:  # timeout after 1 hour and 50 minutes
+        with Timeout(6) as to:  # timeout after 1 hour and 50 minutes
+            runner = self.ingest_store_and_analyze_dataset(dataset_fixture='10x')
             try:
                 self.assertEqual(1, len(runner.primary_bundle_uuids))
                 self.assertEqual(1, len(runner.secondary_bundle_uuids))
@@ -153,6 +154,9 @@ class Test10xRun(TestEndToEndDCP):
                 self.check_manifest_contains_exactly_these_files(results_bundle_manifest, expected_files)
             except:
                 pass
+
+        print()
+        print("test timed out:", to.did_timeout)
 
         runner.cleanup_primary_and_result_bundles()
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -36,6 +36,7 @@ class Timeout(AbstractContextManager):
 
     def __enter__(self):
         def _timeout_handler(signum, frame):
+            self.did_timeout = True
             raise TimeoutError("time's up!")
 
         signal.signal(signal.SIGALRM, _timeout_handler)
@@ -47,8 +48,4 @@ class Timeout(AbstractContextManager):
         signal.signal(signal.SIGALRM, signal.SIG_DFL)
         signal.alarm(0)
 
-        if exc_type == TimeoutError:
-            self.did_timeout = True
-            return True
-
-        return None is exc_type
+        return (None is exc_type) or (TimeoutError is exc_type)


### PR DESCRIPTION
Tested on the integration test with 6 second timeouts.