### PR TITLE
Add better logging around analysis workflows for the dcp test suite

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ stages:
   - 100_cell_test
 
 before_script:
+  - export CI_COMMIT_REF_NAME=integration
   - apt-get -y update
   - apt-get -y install jq
   - pip install -r requirements.txt

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,6 +23,7 @@ dcp_wide_test_SS2:
   only:
     - integration
     - staging
+    - rex-better-logging-for-the-dcp-test-suite
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.TestSmartSeq2Run.test_smartseq2_run
 
@@ -31,5 +32,6 @@ dcp_wide_test_10x:
   only:
     - integration
     - staging
+    - rex-better-logging-for-the-dcp-test-suite
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.Test10xRun.test_10x_run

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ hca>=4.6.0
 openpyxl
 awscli
 hca-ingest
-cromwell-tools==1.1.1
+cromwell-tools>=1.1.2
 termcolor

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ hca>=4.6.0
 openpyxl
 awscli
 hca-ingest
+cromwell-tools==1.1.1
+termcolor

--- a/tests/analysis_agent.py
+++ b/tests/analysis_agent.py
@@ -103,7 +103,7 @@ class AnalysisAgent:
         assert len(all_workflows) == total_count == 1
         return Workflow(all_workflows[0])
 
-    def query_by_bundle(self, bundle_uuid, bundle_version=None, with_labels=True):
+    def query_by_bundle(self, bundle_uuid, bundle_version=None, with_labels=False):
         """Query the analysis workflows by their workflow-UUID.
 
         Note, due to the open issue: https://github.com/broadinstitute/cromwell/issues/3115, if the result of workflows

--- a/tests/analysis_agent.py
+++ b/tests/analysis_agent.py
@@ -126,7 +126,7 @@ class AnalysisAgent:
             }
         }
 
-        if additional_query_result_fields:
+        if with_labels:
             query_dict['additionalQueryResultFields'] = ['labels']
 
         if bundle_version:

--- a/tests/analysis_agent.py
+++ b/tests/analysis_agent.py
@@ -1,0 +1,176 @@
+from cromwell_tools import api as cwm_api
+from cromwell_tools import cromwell_auth as cwm_auth
+from .analysis_entities import Workflow
+from contextlib import contextmanager
+import logging
+
+
+class AnalysisAgent:
+    def __init__(self, deployment, service_account_key):
+        """Agent model for talking to the HCA DCP Secondary-analysis service.
+
+        This model is designed to talk to the HCA DCP Secondary-analysis service, especially the underlying Cromwell
+            Workflow Execution Engine's API without exposing too many technical details to the users.
+
+        Args:
+            deployment (str): String representing the deployment environment to be queried on. It could be:
+                "dev", "integration", "staging" or "prod".
+            service_account_key (str): Optional, path to the service account JSON key file, which is required by
+                authenticate with the Secondary-analysis service (Crowmell API). If not provided, the agent will assume
+                no authentication required for talking to secondary analysis, which is very likely to break or skip
+                a lot of commands that are using this agent.
+                TODO: Add OAuth support to this agent so that users could authenticate through Google/Auth0.
+        """
+        self.deployment = deployment
+        self.cromwell_url = 'https://cromwell.caas-prod.broadinstitute.org'
+        self.cromwell_collection = 'lira-test' if self.deployment == 'integration' else f'lira-{self.deployment}'
+        self.auth = self._get_auth(service_account_key)
+
+    def _get_auth(self, service_account_key):
+        """Helper function to generate the auth object to talk to Secondary-analysis service."""
+        return cwm_auth.CromwellAuth.harmonize_credentials(service_account_key=service_account_key,
+                                                           url=self.cromwell_url)
+
+    @staticmethod
+    @contextmanager
+    def ignore_logging_msg(highest_level=logging.CRITICAL):
+        """A context manager that will prevent any logging messages triggered during the body from being processed.
+
+        Referred to https://gist.github.com/simon-weber/7853144
+        two kind-of hacks here:
+            * can't get the highest logging level in effect => delegate to the user
+            * can't get the current module-level override => use an undocumented (but non-private!) interface
+
+        highest_level (int): The maximum logging level in use. This would only need to be changed if
+            a custom level greater than CRITICAL is defined.
+        """
+        previous_level = logging.root.manager.disable
+
+        logging.disable(highest_level)
+
+        try:
+            yield
+        finally:
+            logging.disable(previous_level)
+
+    def query_by_workflow_uuid(self, uuid):
+        """Query an analysis workflow by its workflow-UUID.
+
+        It is a one to one mapping between UUID and workflow in Secondary-analysis service (Cromwell), so the
+        result should always be a single workflow. The Workflow object returned by this function will look like an
+        object be loaded from the following dictionary:
+
+            {
+                "end": "2019-01-06T20:35:19.533Z",
+                "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                "labels": {
+                    "bundle-uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                    "bundle-version": "2018-11-02T114842.872218Z",
+                    "caas-collection-name": "xxxx-prod",
+                    "cromwell-workflow-id": "cromwell-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                    "project_shortname": "project name",
+                    "project_uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+                    "workflow-name": "AdapterSmartSeq2SingleCell",
+                    "workflow-version": "smartseq2_v2.1.0"
+                },
+                "name": "AdapterSmartSeq2SingleCell",
+                "start": "2019-01-06T20:18:18.102Z",
+                "status": "Succeeded",
+                "submission": "2019-01-06T20:16:30.804Z"
+            }
+
+        Args:
+            uuid (str): Secondary-analysis service (Cromwell) workflow UUID.
+
+        Returns:
+            Workflow: Workflow object.
+
+        Raises:
+            requests.exceptions.HTTPError: When the request to Secondary-analysis service (Cromwell) failed.
+        """
+        query_dict = {
+            'id': uuid,
+            'additionalQueryResultFields': ['labels']
+        }
+        
+        query_dict['label']['caas-collection-name'] = self.cromwell_collection
+
+        response = cwm_api.query(query_dict=query_dict, auth=self.auth)
+        response.raise_for_status()
+        result = response.json()
+        all_workflows = result['results']
+        total_count = result['totalResultsCount']
+        assert len(all_workflows) == total_count == 1
+        return Workflow(all_workflows[0])
+
+    def query_by_bundle(self, bundle_uuid, bundle_version=None, with_labels=True):
+        """Query the analysis workflows by their workflow-UUID.
+
+        Note, due to the open issue: https://github.com/broadinstitute/cromwell/issues/3115, if the result of workflows
+        are more than ~1000, this function will very likely raise an error.
+
+        Args:
+            bundle_uuid (str): HCA DCP bundle UUID.
+            bundle_version (str): Optional, HCA DCP bundle version. By default, it's None.
+            with_labels (bool): Optional, whether to return workflow labels in the results. By default, it's False.
+
+        Returns:
+            List[Workflow]: A list of Workflow objects. E.g. [Workflow_1, ..., Workflow_100]
+
+        Raises:
+            requests.exceptions.HTTPError: When the request to Secondary-analysis service (Cromwell) failed.
+        """
+        query_dict = {
+            'label': {
+                'bundle-uuid': bundle_uuid
+            }
+        }
+
+        if additional_query_result_fields:
+            query_dict['additionalQueryResultFields'] = ['labels']
+
+        if bundle_version:
+            query_dict['label']['bundle-version'] = bundle_version
+        
+        query_dict['label']['caas-collection-name'] = self.cromwell_collection
+
+        response = cwm_api.query(query_dict=query_dict, auth=self.auth)
+        response.raise_for_status()
+        result = response.json()
+        all_workflows = [Workflow(wf) for wf in result['results']]
+        return all_workflows
+
+    def query_by_project_uuid(self, project_uuid, with_labels=True):
+        """Query the analysis workflows by the HCA DCP Ingest submission project-UUID, which is essentially one of the
+            workflow labels.
+
+        Note, due to the open issue: https://github.com/broadinstitute/cromwell/issues/3115, if the result of workflows
+        are more than ~1000, this function will very likely raise an error. The `with_labels` is a flag controlling the
+        behavior of whether to query the workflows asking for the labels in the response, by default it's set to True,
+        so please set it to False if you don't want to risk getting error responses.
+
+        Args:
+            project_uuid (str): HCA DCP Ingest submission project-UUID.
+            with_labels (bool): Optional, whether to return workflow labels in the results. By default, it's False.
+
+        Returns:
+            List[Workflow]: A list of Workflow objects. E.g. [Workflow_1, ..., Workflow_100]
+
+        Raises:
+            requests.exceptions.HTTPError: When the request to Secondary-analysis service (Cromwell) failed.
+        """
+        query_dict = {
+            "label": {
+                "project_uuid": project_uuid
+            }
+        }
+        if with_labels:
+            query_dict['additionalQueryResultFields'] = ['labels']
+        
+        query_dict['label']['caas-collection-name'] = self.cromwell_collection
+
+        response = cwm_api.query(query_dict=query_dict, auth=self.auth)
+        response.raise_for_status()
+        result = response.json()
+        all_workflows = [Workflow(wf) for wf in result['results']]
+        return all_workflows

--- a/tests/analysis_entities.py
+++ b/tests/analysis_entities.py
@@ -1,0 +1,167 @@
+from termcolor import colored
+from abc import abstractmethod
+
+
+class EntityBase:
+
+    @abstractmethod
+    def __str__(self, prefix=""):
+        """Return a textual representation of this entity
+
+        :param prefix: must be output at the start of each line out output
+        :return: a string
+
+        example:
+
+        def __str__(self, prefix=""):
+          return colored(f"MyEntity {self.id}", 'red') + \
+          f"{prefix}    attr1: {self.attr1}\n" + \
+          f"{prefix}    attr2: {self.attr2}\n"
+        """
+
+    @abstractmethod
+    def print(self, prefix="", verbose=False, associated_entities_to_show=None):
+        """Display textual representation of this entity and optionally, associated ones.
+
+        :param prefix: must be output at the start of each line out output
+        :param verbose: display verbose output, pass this on to other entities
+        :param associated_entities_to_show: an array of strings, each of which is an entity name, e.g. "file"
+               that should also be displayed
+        :return: nothing
+        """
+
+
+class Workflow(EntityBase):
+    """ Model an analysis Workflow entity.
+
+    A typical analysis Workflow response from the Secondary-analysis service (Cromwell API), will look like the
+    following:
+    {
+        "end": "2019-01-06T20:35:19.533Z",
+        "id": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        "labels": {
+            "bundle-uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "bundle-version": "2018-11-02T114842.872218Z",
+            "caas-collection-name": "xxxx-prod",
+            "cromwell-workflow-id": "cromwell-aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "project_shortname": "project name",
+            "project_uuid": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+            "workflow-name": "AdapterSmartSeq2SingleCell",
+            "workflow-version": "smartseq2_v2.1.0"
+        },
+        "name": "AdapterSmartSeq2SingleCell",
+        "start": "2019-01-06T20:18:18.102Z",
+        "status": "Succeeded",
+        "submission": "2019-01-06T20:16:30.804Z"
+    }
+
+    Among all of the fields, the labels is usually trivial and expensive to query for. So the default response from
+    Secondary-analysis service (Cromwell API) will not contain the `labels` field unless the client is querying with
+    specific parameters. This model is designed to comply with that rule, which means the `labels` is an optional
+    property to this Workflow object, and will set to None is not provided. However, missing the `labels` field can
+    cause  the functions that are depending on this field to run into errors.
+    """
+
+    def __init__(self, workflow_data):
+        self._load_data(workflow_data)
+
+    def __eq__(self, other):
+        return (isinstance(self, type(other)) and isinstance(other, type(self)) and (
+            self.uuid, self.name, self.status, self.start_time, self.end_time) == (
+                other.uuid, other.name, other.status, other.start_time, other.end_time))
+
+    def __hash__(self):
+        """Calculate the hash of a subset of properties.
+
+        Also, in Python3 world, since key lookups are always followed by the equality check, we could care less
+        about the hash collisions here.
+        """
+        return hash((self.uuid, self.name, self.status))
+
+    def __str__(self, prefix="", verbose=False):
+
+        workflow_info = colored(f"{prefix}Workflow {self.uuid}\n", 'green') + \
+                                f"{prefix}    name={self.name}\n" \
+                                f"{prefix}    status={self.status}\n"
+        if verbose:
+            workflow_info += f"{prefix}    submission_time={self.submission_time}\n" \
+                             f"{prefix}    start_time={self.start_time}\n" \
+                             f"{prefix}    end_time={self.end_time}\n"
+
+        if self.labels:
+            workflow_info += colored(f"{prefix}    labels: \n", 'blue')
+            for label_key, label_value in self.labels.items():
+                if label_value:
+                    workflow_info += colored(f"{prefix}        {label_key}={label_value}\n")
+        return workflow_info
+
+    def __repr__(self):
+        return self.uuid
+
+    def _load_data(self, workflow_data):
+        assert isinstance(workflow_data, dict)
+        self._uuid = workflow_data['id']
+        self._name = workflow_data.get('name', '')
+        self._status = workflow_data['status']
+        self._start_time = workflow_data.get('start', '')
+        self._end_time = workflow_data.get('end', '')
+        self._submission_time = workflow_data.get('submission', '')
+
+        if not workflow_data.get('labels'):
+            self._labels = None
+        else:
+            self._labels = {
+                'bundle-uuid': workflow_data['labels'].get('bundle-uuid', ''),
+                'bundle-version': workflow_data['labels'].get('bundle-version', ''),
+                'project_uuid': workflow_data['labels'].get('project_uuid', ''),
+                'project_shortname': workflow_data['labels'].get('project_shortname', ''),
+                'workflow-version': workflow_data['labels'].get('workflow-version', ''),
+                'workflow-name': workflow_data['labels'].get('workflow-name', '')
+            }
+
+    @property
+    def uuid(self):
+        return self._uuid
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def status(self):
+        return self._status
+
+    @property
+    def start_time(self):
+        return self._start_time
+
+    @property
+    def end_time(self):
+        return self._end_time
+
+    @property
+    def submission_time(self):
+        return self._submission_time
+
+    @property
+    def labels(self):
+        return self._labels
+
+    def print(self, prefix="", verbose=False, associated_entities_to_show=None):
+        print(self.__str__(prefix=prefix, verbose=verbose))
+        if associated_entities_to_show:
+            prefix = f"{prefix}    "
+
+            # Show associated bundle
+            # Will raise an error when the `labels` property is missing
+            if any(keyword in associated_entities_to_show for keyword in ('bundles', 'bundle', 'all')):
+                print(f"{prefix}Bundle:")
+                print(prefix + "    " + self.labels.get('bundle-uuid'))
+
+            # Show associated project
+            # Will raise an error when the `labels` property is missing
+            if any(keyword in associated_entities_to_show for keyword in ('projects', 'project', 'all')):
+                print(f"{prefix}Project Shortname:")
+                print(prefix + "    " + self.labels.get('project_shortname'))
+                print(f"{prefix}Project UUID:")
+                print(prefix + "    " + self.labels.get('project_uuid'))

--- a/tests/analysis_entities.py
+++ b/tests/analysis_entities.py
@@ -78,7 +78,7 @@ class Workflow(EntityBase):
         """
         return hash((self.uuid, self.name, self.status))
 
-    def __str__(self, prefix="", verbose=False):
+    def __str__(self, prefix="\t", verbose=False):
 
         workflow_info = colored(f"{prefix}Workflow {self.uuid}\n", 'green') + \
                                 f"{prefix}    name={self.name}\n" \

--- a/tests/analysis_entities.py
+++ b/tests/analysis_entities.py
@@ -76,7 +76,7 @@ class Workflow(EntityBase):
         Also, in Python3 world, since key lookups are always followed by the equality check, we could care less
         about the hash collisions here.
         """
-        return hash((self.uuid, self.name, self.status))
+        return hash((self.uuid, self.name))
 
     def __str__(self, prefix="\t", verbose=False):
 

--- a/tests/dataset_runner.py
+++ b/tests/dataset_runner.py
@@ -185,7 +185,7 @@ class DatasetRunner:
             Progress.report("WAITING FOR ANALYSIS WORKFLOW(s) TO FINISH...")
             WaitFor(
                 self._count_analysis_workflows_and_report
-            )
+            ).to_return_value(value=self.expected_bundle_count)
             
     def _count_analysis_workflows_and_report(self):
         if self._analysis_workflows_count() < self.expected_bundle_count:

--- a/tests/dataset_runner.py
+++ b/tests/dataset_runner.py
@@ -233,7 +233,7 @@ class DatasetRunner:
             self._primary_bundle_count(),
             self.expected_bundle_count
         ))
-        return self._primary_bundles_count()
+        return self._primary_bundle_count()
 
     def _count_secondary_bundles_and_report(self):
         if self._results_bundles_count() < self.expected_bundle_count:

--- a/tests/dataset_runner.py
+++ b/tests/dataset_runner.py
@@ -1,4 +1,5 @@
 import os
+import json
 import requests
 import subprocess
 
@@ -45,7 +46,7 @@ class DatasetRunner:
         gcp_credentials_file_for_analysis = os.environ.get('GCP_ACCOUNT_ANALYSIS_INFO')
         if gcp_credentials_file_for_analysis:
             self.analysis_agent = AnalysisAgent(deployment=deployment, 
-                                                service_account_key=gcp_credentials_file_for_analysis)
+                                                service_account_key=json.loads(gcp_credentials_file_for_analysis))
 
     @property
     def primary_bundle_uuids(self):

--- a/tests/dataset_runner.py
+++ b/tests/dataset_runner.py
@@ -190,7 +190,7 @@ class DatasetRunner:
     def _count_analysis_workflows_and_report(self):
         if self._analysis_workflows_count() < self.expected_bundle_count:
             self._count_analysis_workflows()
-        Progress.report("  analysis workflows: {}/{}".format(
+        Progress.report("  successful analysis workflows: {}/{}".format(
             self._analysis_workflows_count(),
             self.expected_bundle_count
         ))

--- a/tests/dataset_runner.py
+++ b/tests/dataset_runner.py
@@ -205,17 +205,17 @@ class DatasetRunner:
             self._batch_count_analysis_workflows_by_project_shortname()
         if self._results_bundles_count() < self.expected_bundle_count:
             self._count_results_bundles()
-        Progress.report("  bundles: primary: {0}/{1}, results: {2}/{3} \n  workflows: running: {4}/{5}, \
-                        succeeded: {6}/{7}, failed: {8}/{9}".format(
+        Progress.report("  primary bundles: {0}/{1} \n  workflows: running: {2}/{3}, \
+                        succeeded: {4}/{5}, failed: {6}/{7} \n   results bundles: {8}/{9} ".format(
             self._primary_bundle_count(),
             self.expected_bundle_count,
-            self._results_bundles_count(),
-            self._primary_bundle_count(),
             self._ongoing_analysis_workflows_count(),
             self._primary_bundle_count(),
             self._successful_analysis_workflows_count(),
             self._primary_bundle_count(),
             self._failed_analysis_workflows_count(),
+            self._primary_bundle_count(),
+            self._results_bundles_count(),
             self._primary_bundle_count()
         ))
         return self._results_bundles_count()

--- a/tests/dataset_runner.py
+++ b/tests/dataset_runner.py
@@ -201,7 +201,7 @@ class DatasetRunner:
             # TODO: remove the following line once there are no more scalability concerns of the analysis agent
             with self.analysis_agent.ignore_logging_msg():
                 try:
-                    workflows = self.analysis_agent.query_by_bundle(bundle_uuid=bundle_uuid)
+                    workflows = self.analysis_agent.query_by_bundle(bundle_uuid=bundle_uuid, with_labels=False)
 
                     # NOTE: this one-bundle-one-workflow mechanism might change in the future
                     if len(workflows) > 1:

--- a/tests/dataset_runner.py
+++ b/tests/dataset_runner.py
@@ -42,7 +42,7 @@ class DatasetRunner:
         self.failure_reason = None
         self.analysis_workflow_set = set([])
 
-        gcp_credentials_file_for_analysis = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS')
+        gcp_credentials_file_for_analysis = os.environ.get('GCP_ACCOUNT_ANALYSIS_INFO')
         if gcp_credentials_file_for_analysis:
             self.analysis_agent = AnalysisAgent(deployment=deployment, 
                                                 service_account_key=gcp_credentials_file_for_analysis)


### PR DESCRIPTION
I have tested this PR in both happy paths and unhappy paths:
- Unhappy path 1 No creds provided for analysis: https://allspark.dev.data.humancellatlas.org/HumanCellAtlas/dcp/pipelines/8561
- Unhappy path 2 Workflow got aborted in the middle of the test (similar to the workflow failed in the process): https://allspark.dev.data.humancellatlas.org/HumanCellAtlas/dcp/-/jobs/23520
- Happy paths: 
    - the test ran through analysis and show all of the info in the console: 
        https://allspark.dev.data.humancellatlas.org/HumanCellAtlas/dcp/-/jobs/23522
    - the test2 ran through analysis and show all of the info in the console: 
        https://allspark.dev.data.humancellatlas.org/HumanCellAtlas/dcp/-/jobs/24026