### PR TITLE
Add Optimus to integration test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,6 @@ stages:
   - 100_cell_test
 
 before_script:
-  - export CI_COMMIT_REF_NAME=integration
   - apt-get -y update
   - apt-get -y install jq
   - pip install -r requirements.txt
@@ -24,7 +23,6 @@ dcp_wide_test_SS2:
   only:
     - integration
     - staging
-    - se-add-optimus-test
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.TestSmartSeq2Run.test_smartseq2_run
 
@@ -33,6 +31,5 @@ dcp_wide_test_optimus:
   only:
     - integration
     - staging
-    - se-add-optimus-test
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.TestOptimusRun.test_optimus_run

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,3 +33,11 @@ dcp_wide_test_10x:
     - staging
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.Test10xRun.test_10x_run
+
+dcp_wide_test_optimus:
+  stage: dcp_wide_test
+  only:
+    - integration
+    - staging
+  script:
+    - python -m unittest tests.integration.test_end_to_end_dcp.TestOptimusRun.test_optimus_run

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,14 +26,6 @@ dcp_wide_test_SS2:
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.TestSmartSeq2Run.test_smartseq2_run
 
-dcp_wide_test_10x:
-  stage: dcp_wide_test
-  only:
-    - integration
-    - staging
-  script:
-    - python -m unittest tests.integration.test_end_to_end_dcp.Test10xRun.test_10x_run
-
 dcp_wide_test_optimus:
   stage: dcp_wide_test
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ stages:
   - 100_cell_test
 
 before_script:
+  - export CI_COMMIT_REF_NAME=integration
   - apt-get -y update
   - apt-get -y install jq
   - pip install -r requirements.txt
@@ -23,6 +24,7 @@ dcp_wide_test_SS2:
   only:
     - integration
     - staging
+    - se-add-optimus-test
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.TestSmartSeq2Run.test_smartseq2_run
 
@@ -31,5 +33,6 @@ dcp_wide_test_optimus:
   only:
     - integration
     - staging
+    - se-add-optimus-test
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.TestOptimusRun.test_optimus_run

--- a/tests/dataset_runner.py
+++ b/tests/dataset_runner.py
@@ -99,7 +99,7 @@ class DatasetRunner:
                 self.wait_for_primary_bundles()
                 self.wait_for_analysis_workflows()
                 self.wait_for_secondary_bundles()
-            if self.dataset.name == "Smart-seq2":
+            if self.dataset.name == "Smart-seq2" or self.dataset.name == "optimus":
                 self.retrieve_zarr_output_from_matrix_service()
                 self.retrieve_loom_output_from_matrix_service()
             self.assert_data_browser_bundles()

--- a/tests/dataset_runner.py
+++ b/tests/dataset_runner.py
@@ -99,9 +99,9 @@ class DatasetRunner:
                 self.wait_for_primary_bundles()
                 self.wait_for_analysis_workflows()
                 self.wait_for_secondary_bundles()
-            if self.dataset.name == "Smart-seq2" or self.dataset.name == "optimus":
-                self.retrieve_zarr_output_from_matrix_service()
-                self.retrieve_loom_output_from_matrix_service()
+            #if self.dataset.name == "Smart-seq2" or self.dataset.name == "optimus":
+            #    self.retrieve_zarr_output_from_matrix_service()
+            #    self.retrieve_loom_output_from_matrix_service()
             self.assert_data_browser_bundles()
 
         if self.failure_reason:

--- a/tests/fixtures/datasets/optimus/README.json
+++ b/tests/fixtures/datasets/optimus/README.json
@@ -1,5 +1,5 @@
 {
   "data_files_location": "s3://org-humancellatlas-dcp-test-data/optimus/",
-  "spreadsheet_location": "https://raw.github.com/HumanCellAtlas/metadata-schema/se-update-optimus-test-files/infrastructure_testing_files/current/dcp_integration_test_metadata_1_optimus_10X_bundle.xlsx",
+  "spreadsheet_location": "https://raw.github.com/HumanCellAtlas/metadata-schema/DEPLOYMENT/infrastructure_testing_files/current/dcp_integration_test_metadata_1_optimus_10X_bundle.xlsx",
   "expected_bundle_count": 1
 }

--- a/tests/fixtures/datasets/optimus/README.json
+++ b/tests/fixtures/datasets/optimus/README.json
@@ -1,0 +1,5 @@
+{
+  "data_files_location": "s3://org-humancellatlas-dcp-test-data/optimus/",
+  "spreadsheet_location": "https://raw.github.com/HumanCellAtlas/metadata-schema/DEPLOYMENT/infrastructure_testing_files/current/dcp_integration_test_metadata_1_optimus_10X_bundle.xlsx",
+  "expected_bundle_count": 1
+}

--- a/tests/fixtures/datasets/optimus/README.json
+++ b/tests/fixtures/datasets/optimus/README.json
@@ -1,5 +1,5 @@
 {
   "data_files_location": "s3://org-humancellatlas-dcp-test-data/optimus/",
-  "spreadsheet_location": "https://raw.github.com/HumanCellAtlas/metadata-schema/DEPLOYMENT/infrastructure_testing_files/current/dcp_integration_test_metadata_1_optimus_10X_bundle.xlsx",
+  "spreadsheet_location": "https://raw.github.com/HumanCellAtlas/metadata-schema/se-update-optimus-test-files/infrastructure_testing_files/current/dcp_integration_test_metadata_1_optimus_10X_bundle.xlsx",
   "expected_bundle_count": 1
 }

--- a/tests/integration/test_end_to_end_dcp.py
+++ b/tests/integration/test_end_to_end_dcp.py
@@ -212,7 +212,7 @@ class TestOptimusRun(TestEndToEndDCP):
     def test_optimus_run(self):
         runner = DatasetRunner(deployment=self.deployment)
 
-        with Timeout(180 * 60) as to:  # timeout after 3 hours
+        with Timeout(210 * 60) as to:  # timeout after 3 hours
             self.ingest_store_and_analyze_dataset(runner, dataset_fixture='optimus')
             try:
                 self.assertEqual(1, len(runner.primary_bundle_uuids))

--- a/tests/integration/test_end_to_end_dcp.py
+++ b/tests/integration/test_end_to_end_dcp.py
@@ -123,46 +123,6 @@ class TestSmartSeq2Run(TestEndToEndDCP):
             raise TimeoutError("test timed out")
 
 
-class Test10xRun(TestEndToEndDCP):
-
-    CELLRANGER_10X_ANALYSIS_OUTPUT_FILES_REGEXES = [
-        re.compile('metrics\_summary\.csv$'),
-        re.compile('possorted\_genome\_bam\.bam$'),
-        re.compile('possorted\_genome\_bam\.bam\.bai$'),
-        re.compile('barcodes\.tsv$'),
-        re.compile('genes\.tsv$'),
-        re.compile('matrix\.mtx$'),
-        re.compile('filtered\_gene\_bc\_matrices\_h5.h5$'),
-        re.compile('raw\_gene\_bc\_matrices\_h5.h5$'),
-        re.compile('raw\_barcodes\.tsv$'),
-        re.compile('raw\_genes\.tsv$'),
-        re.compile('raw\_matrix\.mtx$'),
-        re.compile('molecule\_info\.h5$'),
-        re.compile('web\_summary\.html$')
-    ]
-
-    def test_10x_run(self):
-        runner = DatasetRunner(deployment=self.deployment)
-
-        with Timeout(110 * 60) as to:  # timeout after 1 hour and 50 minutes
-            self.ingest_store_and_analyze_dataset(runner, dataset_fixture='10x')
-            try:
-                self.assertEqual(1, len(runner.primary_bundle_uuids))
-                self.assertEqual(1, len(runner.secondary_bundle_uuids))
-                expected_files = self.expected_results_bundle_files(runner.primary_bundle_uuids[0],
-                                                                    self.CELLRANGER_10X_ANALYSIS_OUTPUT_FILES_REGEXES)
-                results_bundle_manifest = self.data_store.bundle_manifest(runner.secondary_bundle_uuids[0])
-    
-                self.check_manifest_contains_exactly_these_files(results_bundle_manifest, expected_files)
-            except:
-                pass
-
-        runner.cleanup_primary_and_result_bundles()
-
-        if to.did_timeout:
-            raise TimeoutError("test timed out")
-
-
 class TestOptimusRun(TestEndToEndDCP):
 
     OPTIMUS_10X_ANALYSIS_OUTPUT_FILES_REGEXES = [
@@ -212,7 +172,7 @@ class TestOptimusRun(TestEndToEndDCP):
     def test_optimus_run(self):
         runner = DatasetRunner(deployment=self.deployment)
 
-        with Timeout(210 * 60) as to:  # timeout after 3 hours
+        with Timeout(210 * 60) as to:  # timeout after 3.5 hours (same as Gitlab runner setting)
             self.ingest_store_and_analyze_dataset(runner, dataset_fixture='optimus')
             try:
                 self.assertEqual(1, len(runner.primary_bundle_uuids))

--- a/tests/integration/test_end_to_end_dcp.py
+++ b/tests/integration/test_end_to_end_dcp.py
@@ -163,5 +163,73 @@ class Test10xRun(TestEndToEndDCP):
             raise TimeoutError("test timed out")
 
 
+class TestOptimusRun(TestEndToEndDCP):
+
+    OPTIMUS_10X_ANALYSIS_OUTPUT_FILES_REGEXES = [
+        re.compile('merged\.bam$'),
+        re.compile('sparse\_counts\.npz$'),
+        re.compile('sparse\_counts\_row\_index\.npy$'),
+        re.compile('sparse\_counts\_col\_index\.npy$'),
+        re.compile('merged-cell-metrics\.csv\.gz$'),
+        re.compile('merged-gene-metrics\.csv\.gz$'),
+        re.compile('empty\_drops\_result\.csv$'),
+        re.compile('^.+zarr!\.zattrs$'),
+        re.compile('^.+zarr!\.zgroup$'),
+        re.compile('^.+zarr!expression_matrix!\.zgroup$'),
+        re.compile('^.+zarr!expression_matrix!cell_id!\.zarray$'),
+        re.compile('^.+zarr!expression_matrix!cell_id!0$'),
+        re.compile('^.+zarr!expression_matrix!cell_id!1$'),
+        re.compile('^.+zarr!expression_matrix!cell_metadata_numeric!\.zarray$'),
+        re.compile('^.+zarr!expression_matrix!cell_metadata_numeric!0\.0$'),
+        re.compile('^.+zarr!expression_matrix!cell_metadata_numeric_name!\.zarray$'),
+        re.compile('^.+zarr!expression_matrix!cell_metadata_numeric_name!0$'),
+        re.compile('^.+zarr!expression_matrix!expression!\.zarray$'),
+        re.compile('^.+zarr!expression_matrix!expression!0\.0$'),
+        re.compile('^.+zarr!expression_matrix!expression!0\.1$'),
+        re.compile('^.+zarr!expression_matrix!expression!0\.2$'),
+        re.compile('^.+zarr!expression_matrix!expression!0\.3$'),
+        re.compile('^.+zarr!expression_matrix!expression!0\.4$'),
+        re.compile('^.+zarr!expression_matrix!expression!0\.5$'),
+        re.compile('^.+zarr!expression_matrix!expression!1\.0$'),
+        re.compile('^.+zarr!expression_matrix!expression!1\.1$'),
+        re.compile('^.+zarr!expression_matrix!expression!1\.2$'),
+        re.compile('^.+zarr!expression_matrix!expression!1\.3$'),
+        re.compile('^.+zarr!expression_matrix!expression!1\.4$'),
+        re.compile('^.+zarr!expression_matrix!expression!1\.5$'),
+        re.compile('^.+zarr!expression_matrix!gene_id!\.zarray$'),
+        re.compile('^.+zarr!expression_matrix!gene_id!0$'),
+        re.compile('^.+zarr!expression_matrix!gene_id!1$'),
+        re.compile('^.+zarr!expression_matrix!gene_id!2$'),
+        re.compile('^.+zarr!expression_matrix!gene_id!3$'),
+        re.compile('^.+zarr!expression_matrix!gene_id!4$'),
+        re.compile('^.+zarr!expression_matrix!gene_id!5$'),
+        re.compile('^.+zarr!expression_matrix!gene_metadata_numeric!\.zarray$'),
+        re.compile('^.+zarr!expression_matrix!gene_metadata_numeric!0\.0$'),
+        re.compile('^.+zarr!expression_matrix!gene_metadata_numeric_name!\.zarray$'),
+        re.compile('^.+zarr!expression_matrix!gene_metadata_numeric_name!0$')
+    ]
+
+    def test_optimus_run(self):
+        runner = DatasetRunner(deployment=self.deployment)
+
+        with Timeout(110 * 60) as to:  # timeout after 1 hour and 50 minutes
+            self.ingest_store_and_analyze_dataset(runner, dataset_fixture='optimus')
+            try:
+                self.assertEqual(1, len(runner.primary_bundle_uuids))
+                self.assertEqual(1, len(runner.secondary_bundle_uuids))
+                expected_files = self.expected_results_bundle_files(runner.primary_bundle_uuids[0],
+                                                                    self.OPTIMUS_10X_ANALYSIS_OUTPUT_FILES_REGEXES)
+                results_bundle_manifest = self.data_store.bundle_manifest(runner.secondary_bundle_uuids[0])
+
+                self.check_manifest_contains_exactly_these_files(results_bundle_manifest, expected_files)
+            except:
+                pass
+
+        runner.cleanup_primary_and_result_bundles()
+
+        if to.did_timeout:
+            raise TimeoutError("test timed out")
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/integration/test_end_to_end_dcp.py
+++ b/tests/integration/test_end_to_end_dcp.py
@@ -212,7 +212,7 @@ class TestOptimusRun(TestEndToEndDCP):
     def test_optimus_run(self):
         runner = DatasetRunner(deployment=self.deployment)
 
-        with Timeout(110 * 60) as to:  # timeout after 1 hour and 50 minutes
+        with Timeout(180 * 60) as to:  # timeout after 3 hours
             self.ingest_store_and_analyze_dataset(runner, dataset_fixture='optimus')
             try:
                 self.assertEqual(1, len(runner.primary_bundle_uuids))


### PR DESCRIPTION
This PR adds a test for the Optimus pipeline, which should be run as a part of the integration tests after the pipeline is running in the DCP. 