### PR TITLE
Disable cellranger integration test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,11 +25,3 @@ dcp_wide_test_SS2:
     - staging
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.TestSmartSeq2Run.test_smartseq2_run
-
-dcp_wide_test_10x:
-  stage: dcp_wide_test
-  only:
-    - integration
-    - staging
-  script:
-    - python -m unittest tests.integration.test_end_to_end_dcp.Test10xRun.test_10x_run


### PR DESCRIPTION
Disable the test since it will be replaced by the test for the Optimus pipeline.