### PR TITLE
Remove empty_drops_result

### DIFF
--- a/tests/integration/test_end_to_end_dcp.py
+++ b/tests/integration/test_end_to_end_dcp.py
@@ -130,7 +130,7 @@ class TestOptimusRun(TestEndToEndDCP):
         re.compile('sparse\_counts\_col\_index\.npy$'),
         re.compile('merged-cell-metrics\.csv\.gz$'),
         re.compile('merged-gene-metrics\.csv\.gz$'),
-        re.compile('empty\_drops\_result\.csv$'),
+        #re.compile('empty\_drops\_result\.csv$'),
         re.compile('^.+zarr!\.zattrs$'),
         re.compile('^.+zarr!\.zgroup$'),
         re.compile('^.+zarr!expression_matrix!\.zgroup$'),


### PR DESCRIPTION
Temporarily remove this until this file is submitted with the rest of the pipeline results.