### PR TITLE
Abort running workflows if test times out

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@ stages:
   - 100_cell_test
 
 before_script:
+  - export CI_COMMIT_REF_NAME=integration
   - apt-get -y update
   - apt-get -y install jq
   - pip install -r requirements.txt
@@ -23,6 +24,7 @@ dcp_wide_test_SS2:
   only:
     - integration
     - staging
+    - se-abort-workflows-on-failure
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.TestSmartSeq2Run.test_smartseq2_run
 
@@ -31,5 +33,6 @@ dcp_wide_test_optimus:
   only:
     - integration
     - staging
+    - se-abort-workflows-on-failure
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.TestOptimusRun.test_optimus_run

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,6 @@ stages:
   - 100_cell_test
 
 before_script:
-  - export CI_COMMIT_REF_NAME=integration
   - apt-get -y update
   - apt-get -y install jq
   - pip install -r requirements.txt
@@ -24,7 +23,6 @@ dcp_wide_test_SS2:
   only:
     - integration
     - staging
-    - se-abort-workflows-on-failure
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.TestSmartSeq2Run.test_smartseq2_run
 
@@ -33,6 +31,5 @@ dcp_wide_test_optimus:
   only:
     - integration
     - staging
-    - se-abort-workflows-on-failure
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.TestOptimusRun.test_optimus_run

--- a/tests/analysis_agent.py
+++ b/tests/analysis_agent.py
@@ -90,10 +90,11 @@ class AnalysisAgent:
         """
         query_dict = {
             'id': uuid,
-            'additionalQueryResultFields': ['labels']
+            'additionalQueryResultFields': ['labels'],
+            'label': {
+                'caas-collection-name': self.cromwell_collection
+            }
         }
-        
-        query_dict['label']['caas-collection-name'] = self.cromwell_collection
 
         response = cwm_api.query(query_dict=query_dict, auth=self.auth)
         response.raise_for_status()

--- a/tests/analysis_agent.py
+++ b/tests/analysis_agent.py
@@ -211,3 +211,21 @@ class AnalysisAgent:
         result = response.json()
         all_workflows = [Workflow(wf) for wf in result['results']]
         return all_workflows
+
+    def abort_workflow(self, uuid):
+        """Abort a running analysis workflow in Cromwell by its workflow-UUID.
+
+        Args:
+            uuid (str): Secondary-analysis service (Cromwell) workflow UUID.
+
+        Returns:
+            requests.Response.json: JSON response from Cromwell.
+
+        Raises:
+            requests.exceptions.HTTPError: When the request to Secondary-analysis service (Cromwell) failed.
+
+        """
+        response = cwm_api.abort(uuid=uuid, auth=self.auth)
+        response.raise_for_status()
+        result = response.json()
+        return result

--- a/tests/dataset_runner.py
+++ b/tests/dataset_runner.py
@@ -243,7 +243,7 @@ class DatasetRunner:
             self._successful_analysis_workflows_count(),
             self.expected_bundle_count
         ))
-        return self._analysis_workflows_count()
+        return self._successful_analysis_workflows_count()
 
     def _batch_count_analysis_workflows_by_project_shortname(self):
         """This should only be used for the scaling test"""

--- a/tests/dataset_runner.py
+++ b/tests/dataset_runner.py
@@ -237,10 +237,10 @@ class DatasetRunner:
             ).to_return_value(value=self.expected_bundle_count)
             
     def _count_analysis_workflows_and_report(self):
-        if self._analysis_workflows_count() < self.expected_bundle_count:
+        if self._successful_analysis_workflows_count() < self.expected_bundle_count:
             self._count_analysis_workflows()
         Progress.report("  successful analysis workflows: {}/{}".format(
-            self._analysis_workflows_count(),
+            self._successful_analysis_workflows_count(),
             self.expected_bundle_count
         ))
         return self._analysis_workflows_count()
@@ -261,6 +261,7 @@ class DatasetRunner:
             with self.analysis_agent.ignore_logging_msg():
                 try:
                     workflows = self.analysis_agent.query_by_bundle(bundle_uuid=bundle_uuid, with_labels=False)
+                    self.analysis_workflow_set.update(workflows)
 
                     # NOTE: this one-bundle-one-workflow mechanism might change in the future
                     if len(workflows) > 1:
@@ -270,11 +271,9 @@ class DatasetRunner:
                         if workflow.status in ('Failed', 'Aborted', 'Aborting'):
                             raise Exception(f"The status of workflow {workflow.uuid} is: {workflow.status}")
                         if workflow.status == 'Succeeded':
-                            if workflow not in self.analysis_workflow_set:
-                                Progress.report(f"    workflow succeeded for bundle {bundle_uuid}: \n     {workflow}")
-                                self.analysis_workflow_set.add(workflow)
+                            Progress.report(f"    workflow succeeded for bundle {bundle_uuid}: \n     {workflow}")
                         else:
-                                Progress.report(f"    Found workflow for bundle {bundle_uuid}: \n     {workflow}")
+                            Progress.report(f"    Found workflow for bundle {bundle_uuid}: \n     {workflow}")
                 except requests.exceptions.HTTPError:
                     # Progress.report("ENCOUNTERED AN ERROR FETCHING WORKFLOW INFO, RETRY NEXT TIME...")
                     continue
@@ -412,6 +411,13 @@ class DatasetRunner:
         Progress.report("Project removed from index files: {}, projects: {}, specimens: {}".format(*results_empty))
         return all(results_empty)
 
+    def _assert_workflows_are_aborted(self, workflows):
+        statuses = []
+        for analysis_workflow in workflows:
+            workflow = self.analysis_agent.query_by_workflow_uuid(uuid=analysis_workflow.uuid)
+            statuses.append(workflow.status)
+        return all([status == 'Aborted' for status in statuses])
+
     def cleanup_primary_and_result_bundles(self):
         for primary_bundle_uuid, secondary_bundle_fqid in self.primary_uuid_to_secondary_bundle_fqid_map.items():
             self.data_store.tombstone_bundle(primary_bundle_uuid)
@@ -421,6 +427,15 @@ class DatasetRunner:
         Progress.report("WAITING FOR BUNDLES TO BE REMOVED FROM AZUL ")
         WaitFor(
             self._assert_project_removed_from_azul
+        ).to_return_value(True)
+
+    def cleanup_analysis_workflows(self):
+        ongoing_workflows = [wf for wf in self.analysis_workflow_set if wf.status in ('Submitted', 'On Hold', 'Running')]
+        for analysis_workflow in ongoing_workflows:
+            self.analysis_agent.abort_workflow(uuid=analysis_workflow.uuid)
+        Progress.report("WAITING FOR WORKFLOW(S) TO BE ABORTED IN CROMWELL")
+        WaitFor(
+            self._assert_workflows_are_aborted, ongoing_workflows
         ).to_return_value(True)
 
     def retrieve_zarr_output_from_matrix_service(self):

--- a/tests/integration/test_end_to_end_dcp.py
+++ b/tests/integration/test_end_to_end_dcp.py
@@ -171,7 +171,7 @@ class TestOptimusRun(TestEndToEndDCP):
     def test_optimus_run(self):
         runner = DatasetRunner(deployment=self.deployment)
 
-        with Timeout(15 * 60) as to:  # timeout after 3.5 hours (same as Gitlab runner setting)
+        with Timeout(210 * 60) as to:  # timeout after 3.5 hours (same as Gitlab runner setting)
             try:
                 self.ingest_store_and_analyze_dataset(runner, dataset_fixture='optimus')
                 self.assertEqual(1, len(runner.primary_bundle_uuids))

--- a/tests/integration/test_end_to_end_dcp.py
+++ b/tests/integration/test_end_to_end_dcp.py
@@ -171,7 +171,7 @@ class TestOptimusRun(TestEndToEndDCP):
     def test_optimus_run(self):
         runner = DatasetRunner(deployment=self.deployment)
 
-        with Timeout(210 * 60) as to:  # timeout after 3.5 hours (same as Gitlab runner setting)
+        with Timeout(15 * 60) as to:  # timeout after 3.5 hours (same as Gitlab runner setting)
             try:
                 self.ingest_store_and_analyze_dataset(runner, dataset_fixture='optimus')
                 self.assertEqual(1, len(runner.primary_bundle_uuids))

--- a/tests/integration/test_end_to_end_dcp.py
+++ b/tests/integration/test_end_to_end_dcp.py
@@ -116,9 +116,9 @@ class TestSmartSeq2Run(TestEndToEndDCP):
                 self.check_manifest_contains_exactly_these_files(results_bundle_manifest, expected_files)
             finally:
                 runner.cleanup_primary_and_result_bundles()
-                runner.cleanup_analysis_workflows()
 
         if to.did_timeout:
+            runner.cleanup_analysis_workflows()
             raise TimeoutError("test timed out")
 
 
@@ -183,9 +183,9 @@ class TestOptimusRun(TestEndToEndDCP):
                 self.check_manifest_contains_exactly_these_files(results_bundle_manifest, expected_files)
             finally:
                 runner.cleanup_primary_and_result_bundles()
-                runner.cleanup_analysis_workflows()
 
         if to.did_timeout:
+            runner.cleanup_analysis_workflows()
             raise TimeoutError("test timed out")
 
 

--- a/tests/integration/test_end_to_end_dcp.py
+++ b/tests/integration/test_end_to_end_dcp.py
@@ -116,6 +116,7 @@ class TestSmartSeq2Run(TestEndToEndDCP):
                 self.check_manifest_contains_exactly_these_files(results_bundle_manifest, expected_files)
             finally:
                 runner.cleanup_primary_and_result_bundles()
+                runner.cleanup_analysis_workflows()
 
         if to.did_timeout:
             raise TimeoutError("test timed out")
@@ -182,6 +183,7 @@ class TestOptimusRun(TestEndToEndDCP):
                 self.check_manifest_contains_exactly_these_files(results_bundle_manifest, expected_files)
             finally:
                 runner.cleanup_primary_and_result_bundles()
+                runner.cleanup_analysis_workflows()
 
         if to.did_timeout:
             raise TimeoutError("test timed out")


### PR DESCRIPTION
**Purpose:**
If a test times out while an analysis workflow is running and the workflow later succeeds, it will result in test analysis bundles that show up in the data browser. This is especially an issue for integration tests running in production. 

**Changes:**
- If the test times out, abort any running workflows in Cromwell and then verify that the status is "Aborted":
https://allspark.dev.data.humancellatlas.org/HumanCellAtlas/dcp/-/jobs/27297

**Note:** 
Any thoughts on how to abort workflows if a test is cancelled would be helpful!!