### PR TITLE
Add GitLab jobs to find and (manually) tombstone test bundles

### DIFF
--- a/.gitlab-prod-ci.yml
+++ b/.gitlab-prod-ci.yml
@@ -2,6 +2,8 @@ image: python:3.6
 
 stages:
   - dcp_wide_test
+  - find_test_bundles
+  - cleanup_test_bundles
 
 before_script:
   - apt-get -y update
@@ -29,3 +31,18 @@ dcp_wide_test_optimus:
     - prod
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.TestOptimusRun.test_optimus_run
+
+find_test_bundles:
+  stage: find_test_bundles
+  only:
+    - prod
+  script:
+    - python -m unittest tests.cleanup.cleanup_test_bundles.CleanupTestBundles.test_find_test_bundles
+
+tombstone_test_bundles:
+  stage: cleanup_test_bundles
+  when: manual
+  only:
+    - prod
+  script:
+    - python -m unittest tests.cleanup.cleanup_test_bundles.CleanupTestBundles.test_tombstone_test_bundles

--- a/tests/cleanup/cleanup_test_bundles.py
+++ b/tests/cleanup/cleanup_test_bundles.py
@@ -12,14 +12,7 @@ class CleanupTestBundles(unittest.TestCase):
           "should": [
             {
               "prefix": {
-                "files.project_json.project_core.project_short_name": "prod"
-              }
-            }
-          ],
-          "must_not": [
-            {
-              "match": {
-                "files.analysis_process_json.type.text": "analysis"
+                "files.project_json.project_core.project_short_name": "prod/"
               }
             }
           ]

--- a/tests/cleanup/cleanup_test_bundles.py
+++ b/tests/cleanup/cleanup_test_bundles.py
@@ -1,23 +1,20 @@
 #!/usr/bin/env python3
-
 import os
+import sys
 import unittest
 
-from ..data_store_agent import DataStoreAgent
+pkg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))  # noqa
+sys.path.insert(0, pkg_root)  # noqa
+
+from data_store_agent import DataStoreAgent
 
 class CleanupTestBundles(unittest.TestCase):
     test_bundle_query = {
-      "query": {
-        "bool": {
-          "should": [
-            {
-              "prefix": {
+        "query": {
+            "prefix": {
                 "files.project_json.project_core.project_short_name": "prod/"
-              }
             }
-          ]
         }
-      }
     }
 
     def setUp(self):

--- a/tests/data_store_agent.py
+++ b/tests/data_store_agent.py
@@ -1,11 +1,9 @@
-import json
 import os
 
 from hca.dss import DSSClient
 from hca.util.exceptions import SwaggerAPIException
 
-from . import logger
-from .utils import Progress
+from utils import Progress
 
 
 class DataStoreAgent:

--- a/tests/data_store_agent.py
+++ b/tests/data_store_agent.py
@@ -27,6 +27,10 @@ class DataStoreAgent:
         except SwaggerAPIException:
             return []
 
+    def search_iterate(self, query, replica='aws'):
+        for hit in self.client.post_search.iterate(replica=replica, es_query=query):
+            yield hit
+
     def download_bundle(self, bundle_uuid, target_folder):
         Progress.report(f"Downloading bundle {bundle_uuid}:\n")
         manifest = self.bundle_manifest(bundle_uuid)


### PR DESCRIPTION
This adds two GitLab jobs that:
  1. Find test bundles in the production deployment of the DSS and output them to the job log. This will run after every DCP-wide integration test.
  1. Tombstone test bundles in the production deployment of the DSS. This must be manually triggered.

For this to work, the DCP-wide integration test service account needs to be authorized to tombstone bundles in the DSS.