### PR TITLE
Continue pipeline if integration tests fail.

### DIFF
--- a/.gitlab-prod-ci.yml
+++ b/.gitlab-prod-ci.yml
@@ -22,6 +22,7 @@ dcp_wide_test_SS2:
   stage: dcp_wide_test
   only:
     - prod
+  allow_failure: true
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.TestSmartSeq2Run.test_smartseq2_run
 
@@ -29,6 +30,7 @@ dcp_wide_test_optimus:
   stage: dcp_wide_test
   only:
     - prod
+  allow_failure: true
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.TestOptimusRun.test_optimus_run
 


### PR DESCRIPTION
This allows test bundle identification and cleanup to proceed even if the dcp-wide integration tests fail. Failed pipelines will be [highlighted orange instead of red](https://docs.gitlab.com/ee/ci/yaml/#allow_failure).