### PR TITLE
Modify test to update bundle metadata

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,6 @@ stages:
   - 100_cell_test
 
 before_script:
-  - export CI_COMMIT_REF_NAME=integration
   - apt-get -y update
   - apt-get -y install jq
   - pip install -r requirements.txt
@@ -33,7 +32,6 @@ dcp_wide_test_metadata_update:
   only:
     - integration
     - staging
-    - se-modify-bundle-update-tests
   script:
     - python -m unittest tests.integration.test_end_to_end_dcp.TestSmartSeq2Run.test_update
 

--- a/tests/integration/test_end_to_end_dcp.py
+++ b/tests/integration/test_end_to_end_dcp.py
@@ -184,7 +184,6 @@ class TestSmartSeq2Run(TestEndToEndDCP):
                 workflows = self.analysis_agent.query_by_bundle(self.primary_bundle)
                 self.analysis_workflow_set.update(workflows)
             except requests.exceptions.HTTPError:
-                # Progress.report("ENCOUNTERED AN ERROR FETCHING WORKFLOW INFO, RETRY NEXT TIME...")
                 pass
 
     def _aborted_analysis_workflows_count(self):


### PR DESCRIPTION
When the metadata in a submission is updated and it does not impact analysis, the workflow that is triggered by the new bundle version will be aborted by Falcon (the secondary analysis workflow starter).

Here is a successful test run: https://allspark.dev.data.humancellatlas.org/HumanCellAtlas/dcp/-/jobs/44212