### PR TITLE
run cleanup on failure

### DIFF
--- a/.gitlab-prod-ci.yml
+++ b/.gitlab-prod-ci.yml
@@ -36,6 +36,7 @@ dcp_wide_test_optimus:
 
 find_test_bundles:
   stage: find_test_bundles
+  when: on_failure
   only:
     - prod
   script:
@@ -43,7 +44,7 @@ find_test_bundles:
 
 tombstone_test_bundles:
   stage: cleanup_test_bundles
-  when: manual
+  when: on_failure
   only:
     - prod
   script:


### PR DESCRIPTION
As discussed, lets run auto cleanup if one of the earlier stages fails. If all stages pass, there is no need to run cleanup as the stages should have cleaned up after themselves.