### PR TITLE
Update CLI requirement to 7.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 awscli
 cromwell-tools>=1.1.2
 faker
-hca>=4.9.0
+hca>=7.0.0
 hca-ingest>=0.6.10
 iso8601
 openpyxl


### PR DESCRIPTION
Update the dcp-cli requirement to 7.0.0 to address offline query service errors. 

For more info see https://github.com/HumanCellAtlas/dcp-cli/commit/700234d2ac05165faf5c7817d6dac8513c115337

